### PR TITLE
Add --version CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `--outputType` Flag to configure output type. Defaults to auto.
+- `--version` Flag to return the version of the dts-linter.
 
 ### Changed
 

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -63,6 +63,7 @@ const schema = z.object({
     .enum(["auto", "pretty", "annotations", "json"])
     .optional()
     .default("auto"),
+  version: z.boolean().optional().default(false),
   help: z.boolean().optional().default(false),
 });
 type SchemaType = z.infer<typeof schema>;
@@ -82,7 +83,8 @@ Options:
   --diagnosticsFull                               Show full diagnostics for files (default: false).
   --showInfoDiagnostics                           Show information diagnostics
   --patchFile <path>                              Write formatting diff output to this file (optional).
-  --outputFormat <auto|pretty|annotations|json>     stdout output type.
+  --outputFormat <auto|pretty|annotations|json>   stdout output type.
+  --version                                       Show version information (default: false).
   --help                                          Show help information (default: false).
 
 Example:
@@ -105,6 +107,7 @@ try {
       showInfoDiagnostics: { type: "boolean" },
       patchFile: { type: "string" },
       outputFormat: { type: "string" },
+      version: { type: "boolean" },
       help: { type: "boolean" },
     },
     strict: true,
@@ -124,6 +127,12 @@ try {
 if (argv.help) {
   console.log("Invalid arguments");
   console.log(helpString);
+  process.exit(0);
+}
+
+if (argv.version) {
+  const pkg = require("../package.json");
+  console.log(`${pkg.name} version ${pkg.version}`);
   process.exit(0);
 }
 

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -130,8 +130,9 @@ if (argv.help) {
   process.exit(0);
 }
 
+import pkg from "../package.json";
+
 if (argv.version) {
-  const pkg = require("../package.json");
   console.log(`${pkg.name} version ${pkg.version}`);
   process.exit(0);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2021",
-    "module": "commonjs",
+    "resolveJsonModule":true,
+    "module": "nodenext",
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
adds a `--version` flag allowing to output the current version of dts-linter.