### PR TITLE
Expose more CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Added CLI options to use spaces for indent, indent width, and default filetypes [Contribution by [urob](https://github.com/urob)]
 - Fixed false-positive formatting failure when diagnostics are present. [Fixed by [urob](https://github.com/urob)]
 - Fixed log message when diff is not able to be generated.
 

--- a/README.md
+++ b/README.md
@@ -35,23 +35,36 @@ dts-linter --formatFixAll
 
 ### Command Line Options
 
-| Option                  | Type            | Default         | Description                                                                                        |
-| ----------------------- | --------------- | --------------- | -------------------------------------------------------------------------------------------------- |
-| `--file`                | string          | Auto-discover   | List of input files (can be repeated)                                                              |
-| `--cwd`                 | string          | `process.cwd()` | Set the current working directory                                                                  |
-| `--include`             | string          | `[]`            | Paths to resolve includes (absolute or relative to CWD, can be repeated)                           |
-| `--binding`             | string          | `[]`            | Zephyr binding root directories (absolute or relative to CWD, can be repeated)                     |
-| `--logLevel`            | `none\|verbose` | `none`          | Set the logging verbosity                                                                          |
-| `--format`              | boolean         | `false`         | Format the specified files (automatically set to true when formatFixAll)                           |
-| `--formatFixAll`        | boolean         | `false`         | Apply formatting changes directly to files                                                         |
-| `--diagnostics`         | boolean         | `false`         | Show basic syntax diagnostics                                                                      |
-| `--diagnosticsFull`     | boolean         | `false`         | Show full diagnostics including semantic analysis (requires --include, --binding for proper usage) |
-| `--diagnosticsConfig`   | string          | -               | Path to json file with test case configurations for complex diagnostics                            |
-| `--showInfoDiagnostics` | boolean         | `false`         | Show information-level diagnostics                                                                 |
-| `--patchFile`           | string          | -               | Write formatting diff output to file                                                               |
-| `--outputType`          | string          | `auto`          | Output format type: auto, pretty, annotations, or json                                             |
-| `--threads`             | number          | `1`             | Number of parallel LSP instances to use for processing files                                       |
-| `--help`                | boolean         | `false`         | Show help information                                                                              |
+| Option                                | Type                              | Default           | Description                                                                                        |
+| ------------------------------------- | --------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
+| `--file`                              | string                            | Auto-discover     | List of input files (can be repeated)                                                              |
+| `--filetypes`                         | string                            | `dts,dtsi,overlay`| Comma-separated file extensions to search when `--file` is not set                                |
+| `--cwd`                               | string                            | `process.cwd()`   | Set the current working directory                                                                  |
+| `--include`                           | string                            | `[]`              | Paths to resolve includes (absolute or relative to CWD, can be repeated)                          |
+| `--binding`                           | string                            | `[]`              | Zephyr binding root directories (absolute or relative to CWD, can be repeated)                    |
+| `--logLevel`                          | `none\|verbose`                   | `none`            | Set the logging verbosity                                                                          |
+| `--format`                            | boolean                           | `false`           | Format the specified files (automatically set to true when formatFixAll)                           |
+| `--formatFixAll`                      | boolean                           | `false`           | Apply formatting changes directly to files                                                         |
+| `--tabSize`                           | number                            | `8`               | Number of spaces per indentation level                                                             |
+| `--insertSpaces`                      | boolean                           | `false`           | Use spaces instead of tabs for indentation                                                         |
+| `--disableBaseFormattingRules`        | boolean                           | `false`           | Disable base formatting rules                                                                      |
+| `--disableIndentExpressions`          | boolean                           | `false`           | Disable indentation for expressions when formatting                                                |
+| `--disableRemoveDuplicateProperties`  | boolean                           | `false`           | Disable removal of duplicate properties in the same scope                                          |
+| `--disableRemoveEmptyReferences`      | boolean                           | `false`           | Disable removal of empty references                                                                |
+| `--enableRemoveEmptyNodes`            | boolean                           | `false`           | Enable removal of empty nodes                                                                      |
+| `--enableRemoveEmptyRoots`            | boolean                           | `false`           | Enable removal of empty root nodes                                                                 |
+| `--enableSortNodesAndProperties`      | boolean                           | `false`           | Enable sorting of nodes and properties                                                             |
+| `--sortNodesNodesBy`                  | `none\|name\|address`             | `none`            | When sorting nodes, sort by name or address                                                        |
+| `--enableSortPropertiesAlphabetically`| boolean                           | `false`           | Enable sorting of properties alphabetically                                                        |
+| `--diagnostics`                       | boolean                           | `false`           | Show basic syntax diagnostics                                                                      |
+| `--diagnosticsFull`                   | boolean                           | `false`           | Show full diagnostics including semantic analysis (requires --include, --binding for proper usage) |
+| `--diagnosticsConfig`                 | string                            | -                 | Path to json file with test case configurations for complex diagnostics                            |
+| `--showInfoDiagnostics`               | boolean                           | `false`           | Show information-level diagnostics                                                                 |
+| `--patchFile`                         | string                            | -                 | Write formatting diff output to file                                                               |
+| `--outputFormat`                      | `auto\|pretty\|annotations\|json` | `auto`            | Output format type                                                                                 |
+| `--threads`                           | number                            | `1`               | Number of parallel LSP instances to use for processing files                                       |
+| `--version`                           | boolean                           | `false`           | Show version information                                                                           |
+| `--help`                              | boolean                           | `false`           | Show help information                                                                              |
 
 ### Examples
 
@@ -87,7 +100,7 @@ dts-linter --format --diagnostics --threads 4
 
 ## File Discovery
 
-When no `--file` option is provided, the linter automatically searches for DeviceTree files using the pattern `**/*.{dts,dtsi,overlay}` or `**/*.{dts}` when using `--diagnosticsFull` in the current working directory.
+When no `--file` option is provided, the linter automatically searches for DeviceTree files using the pattern `**/*.{dts,dtsi,overlay}` (or `**/*.dts` when using `--diagnosticsFull`) in the current working directory. Use `--filetypes` to customize which extensions are searched.
 
 ## Performance and Threading
 

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -227,6 +227,7 @@ const schema = z.object({
     .default("auto"),
   tabSize: z.number().int().min(1).optional().default(8),
   insertSpaces: z.boolean().optional().default(false),
+  filetypes: z.array(z.string()).optional(),
   threads: z.number().int().min(1).optional().default(1),
   version: z.boolean().optional().default(false),
   help: z.boolean().optional().default(false),
@@ -237,6 +238,7 @@ const helpString = `Usage: dts-linter [options]
 
 Options:
   --file                                          List of input files (can be repeated).
+  --filetypes <ext,...>                           Comma-separated list of file extensions to select when --file is not set (default: dts,dtsi,overlay).
   --cwd <path>                                    Set the current working directory.
   --include                                       Paths (absolute or relative to CWD) to resolve includes (default: []).
   --binding                                       Zephyr binding root directories (default: []).
@@ -295,6 +297,7 @@ try {
       insertSpaces: { type: "boolean" },
       patchFile: { type: "string" },
       outputFormat: { type: "string" },
+      filetypes: { type: "string" },
       threads: { type: "string" },
       version: { type: "boolean" },
       help: { type: "boolean" },
@@ -302,11 +305,14 @@ try {
     strict: true,
   });
 
-  // Convert string-typed numeric options to numbers
+  // Convert string-typed numeric options to numbers; split comma-separated filetypes
   const processedValues = {
     ...values,
     tabSize: values.tabSize ? parseInt(values.tabSize, 10) : undefined,
     threads: values.threads ? parseInt(values.threads, 10) : undefined,
+    filetypes: values.filetypes
+      ? values.filetypes.split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined,
   };
 
   const safeParseData = schema.safeParse(processedValues);
@@ -355,6 +361,11 @@ const threads = argv.threads;
 const tabSize = argv.tabSize;
 const insertSpaces = argv.insertSpaces;
 const diagnosticsConfigPath = argv.diagnosticsConfig;
+
+if (argv.filetypes && argv.file) {
+  console.log(`Cannot use --filetypes with --file option.`);
+  process.exit(1);
+}
 
 if (diagnosticsConfigPath && argv.file) {
   console.log(`Cannot use --diagnosticsConfig with --file option.`);
@@ -499,7 +510,12 @@ const jsonOut: { cwd: string; issues: Issue[] } = {
 };
 
 if (!argv.diagnosticsConfig && !argv.file) {
-  const globString = diagnosticsFull ? "**/*.{dts}" : "**/*.{dts,dtsi,overlay}";
+  const defaultTypes = diagnosticsFull ? ["dts"] : ["dts", "dtsi", "overlay"];
+  const activeTypes = argv.filetypes ?? defaultTypes;
+  const globString =
+    activeTypes.length === 1
+      ? `**/*.${activeTypes[0]}`
+      : `**/*.{${activeTypes.join(",")}}`;
   log("info", `Searching for '${globString}' in ${cwd}`);
   argv.file = globSync(globString, {
     cwd: argv.cwd,

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -225,6 +225,8 @@ const schema = z.object({
     .enum(["auto", "pretty", "annotations", "json"])
     .optional()
     .default("auto"),
+  tabSize: z.number().int().min(1).optional().default(8),
+  insertSpaces: z.boolean().optional().default(false),
   threads: z.number().int().min(1).optional().default(1),
   version: z.boolean().optional().default(false),
   help: z.boolean().optional().default(false),
@@ -254,6 +256,8 @@ Options:
   --diagnosticsFull                               Show full diagnostics for files (default: false).
   --diagnosticsConfig <path>                      Path to diagnostics configuration file.
   --showInfoDiagnostics                           Show information diagnostics
+  --tabSize <number>                              Number of spaces per indentation level (default: 8).
+  --insertSpaces                                  Use spaces instead of tabs for indentation (default: false).
   --patchFile <path>                              Write formatting diff output to this file (optional).
   --outputFormat <auto|pretty|annotations|json>   stdout output type.
   --threads <number>                              Number of parallel LSP instances to use (default: 1).
@@ -287,6 +291,8 @@ try {
       diagnosticsFull: { type: "boolean" },
       diagnosticsConfig: { type: "string" },
       showInfoDiagnostics: { type: "boolean" },
+      tabSize: { type: "string" },
+      insertSpaces: { type: "boolean" },
       patchFile: { type: "string" },
       outputFormat: { type: "string" },
       threads: { type: "string" },
@@ -296,9 +302,10 @@ try {
     strict: true,
   });
 
-  // Convert threads string to number if provided
+  // Convert string-typed numeric options to numbers
   const processedValues = {
     ...values,
+    tabSize: values.tabSize ? parseInt(values.tabSize, 10) : undefined,
     threads: values.threads ? parseInt(values.threads, 10) : undefined,
   };
 
@@ -345,6 +352,8 @@ const showInfoDiagnostics = argv.showInfoDiagnostics;
 const outputFormat = argv.outputFormat;
 const patchFile = argv.patchFile;
 const threads = argv.threads;
+const tabSize = argv.tabSize;
+const insertSpaces = argv.insertSpaces;
 const diagnosticsConfigPath = argv.diagnosticsConfig;
 
 if (diagnosticsConfigPath && argv.file) {
@@ -938,8 +947,8 @@ const formatFile = async (
       uri: `file://${absPath}`,
     },
     options: {
-      tabSize: 8,
-      insertSpaces: false,
+      tabSize: tabSize,
+      insertSpaces: insertSpaces,
       trimTrailingWhitespace: true,
       insertFinalNewline: true,
       trimFinalNewlines: true,


### PR DESCRIPTION
This adds a couple more CLI flags:

- `--tabSize <int>` overwrites the default sent by `formatFile` to the lsp
- `--insertSpaces` instructs lsp to use spaces for indenting
- `--filetypes {list}` allows overwriting the default filetypes used when `--file` is not specified

The PR also updates the README with the new flags and a few existing ones that haven't yet been documented.