### PR TITLE
Fix incorrect formatting failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed false-positive formatting failure when diagnostics are present. [Fixed by [urob](https://github.com/urob)]
 - Fixed log message when diff is not able to be generated.
 
 ## [0.5.0] - 2026-04-01

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -1007,7 +1007,7 @@ const formatFile = async (
       } else {
         log(
           "error",
-          `${relative(cwd, absPath)} unable to generate diff due to /* dts-format off */`,
+          `${relative(cwd, absPath)} unable to generate diff to format file.`,
           undefined,
           undefined,
           undefined,

--- a/src/dts-linter.ts
+++ b/src/dts-linter.ts
@@ -969,42 +969,20 @@ const formatFile = async (
   const indent = mainFile ? "" : "\t";
 
   const textIdentical = result && result.text === originalText;
-  if (result && (!textIdentical || result.diagnostics.length)) {
-    const newText = result?.text;
+  if (result && !textIdentical) {
+    const newText = result.text;
     const relativePath = relative(cwd, absPath);
-    let diff: string | null = null;
-    if (!textIdentical) {
-      diff = createPatch(`a/${relativePath}`, originalText, newText);
-      log(
-        "error",
-        diff,
-        absPath,
-        "Not correctly formatted.",
-        undefined,
-        undefined,
-        indent,
-        progressString,
-      );
-    }
-
-    if (outputFormat === "json" || outputFormat === "annotations") {
-      result.diagnostics.forEach((issue) => {
-        log(
-          "error",
-          issue.message,
-          absPath,
-          undefined,
-          {
-            line: issue.range.start.line + 1,
-            col: issue.range.start.character,
-          },
-          {
-            line: issue.range.end.line + 1,
-            col: issue.range.end.character,
-          },
-        );
-      });
-    }
+    const diff = createPatch(`a/${relativePath}`, originalText, newText);
+    log(
+      "error",
+      diff,
+      absPath,
+      "Not correctly formatted.",
+      undefined,
+      undefined,
+      indent,
+      progressString,
+    );
 
     if (diffs.has(absPath)) {
       if (diffs.get(absPath) !== diff && patchFile) {
@@ -1026,20 +1004,18 @@ const formatFile = async (
       });
       if (diff) {
         diffs.set(absPath, diff);
+      } else {
+        log(
+          "error",
+          `${relative(cwd, absPath)} unable to generate diff due to /* dts-format off */`,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          indent,
+          progressString,
+        );
       }
-    }
-
-    if (!diff) {
-      log(
-        "error",
-        `${relative(cwd, absPath)} unable to generate diff due to /* dts-format off */`,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        indent,
-        progressString,
-      );
     }
   } else {
     log(
@@ -1052,6 +1028,25 @@ const formatFile = async (
       indent,
       progressString,
     );
+  }
+
+  if (result && result.diagnostics.length && (outputFormat === "json" || outputFormat === "annotations")) {
+    result.diagnostics.forEach((issue) => {
+      log(
+        "error",
+        issue.message,
+        absPath,
+        undefined,
+        {
+          line: issue.range.start.line + 1,
+          col: issue.range.start.character,
+        },
+        {
+          line: issue.range.end.line + 1,
+          col: issue.range.end.character,
+        },
+      );
+    });
   }
 };
 


### PR DESCRIPTION
This fixes #10 

The issue emerges because when `textIdentical=true` but diagnostics are present, the code enters the outer if block, skips diff creation, and then incorrectly fires the !diff error as a formatting failure.

This PR separates the two concerns.